### PR TITLE
Add ci tests with image caching

### DIFF
--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -1,0 +1,55 @@
+name: opentile pytest
+
+on: [push, pull_request]
+
+jobs:
+  # RUN PYTEST
+  tests:
+    name: pytest ${{ matrix.os }}::py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 6
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.8]
+        include:
+          # we'll test the python support on ubuntu
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: 3.9
+          - os: ubuntu-latest
+            python-version: 3.7
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up libjpegturbo Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y libturbojpeg
+      - name: Set up libjpegturbo OSX
+        if: matrix.os == 'macos-latest'
+        run: brew install jpeg-turbo
+      - name: Set up libjpegturbo Windows
+        shell: pwsh
+        if: matrix.os == 'windows-latest'
+        run: |
+          Invoke-WebRequest -Uri https://sourceforge.net/projects/libjpeg-turbo/files/2.1.2/libjpeg-turbo-2.1.2-vc64.exe/download -OutFile libjpeg-turbo-2.1.2-vc64.exe -UserAgent "NativeHost"
+          7z e libjpeg-turbo-2.1.2-vc64.exe -oC:\Windows\System32 bin/turbojpeg.dll
+
+      - name: Update pip and install pytest
+        run: |
+          python -m pip install -U pip
+          python -m pip install pytest
+
+      - name: Install opentile
+        run: python -m pip install .
+
+      - name: Run tests
+        run: pytest -v tests/

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -3,8 +3,27 @@ name: opentile pytest
 on: [push, pull_request]
 
 jobs:
+  cache_test_images:
+    name: cache test images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load test images from cache
+        id: cache-test-images
+        uses: actions/cache@v2
+        with:
+          key: test-image-cache-v1.0.1
+          path: OPEN_TILER_TEST
+      - name: Load test images
+        if: steps.cache-test-images.outputs.cache-hit != 'true'
+        # we should call a script provided in the repo
+        run: |
+          mkdir -p OPEN_TILER_TEST
+          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/CMU-1.svs -P OPEN_TILER_TEST/svs/CMU-1/
+          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu/CMU-1.ndpi -P OPEN_TILER_TEST/ndpi/CMU-1/
+
   # RUN PYTEST
   tests:
+    needs: [ cache_test_images ]
     name: pytest ${{ matrix.os }}::py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -30,6 +49,24 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # cross os caching support, see: https://github.com/actions/cache/issues/591
+      - name: "Use GNU tar instead BSD tar"
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+      - name: Load test images from cache
+        id: cache-test-images
+        uses: actions/cache@v2
+        with:
+          key: test-image-cache-v1.0.1
+          path: OPEN_TILER_TEST
+      - name: Check test images are loaded
+        if: steps.cache-test-images.outputs.cache-hit != 'true'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('test images were not cached')
+
       - name: Set up libjpegturbo Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y libturbojpeg
@@ -52,4 +89,6 @@ jobs:
         run: python -m pip install .
 
       - name: Run tests
+        env:
+          OPEN_TILER_TESTDIR: OPEN_TILER_TEST
         run: pytest -v tests/

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -107,4 +107,5 @@ jobs:
       - name: Run tests
         env:
           OPENTILE_TESTDIR: OPENTILE_TESTDATA
+          TURBOJPEG: C:\Windows\System32
         run: pytest -v tests/

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -7,21 +7,23 @@ jobs:
     name: cache test images
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
       - name: Load test images from cache
         id: cache-test-images
         uses: actions/cache@v2
         with:
-          key: test-image-cache-v1.0.1
-          path: OPEN_TILER_TEST
+          key: test-images-cache-${{ hashFiles('tests/download_test_images.py') }}
+          path: OPENTILE_TESTDATA
       - name: Load test images
         if: steps.cache-test-images.outputs.cache-hit != 'true'
-        # we should call a script provided in the repo
+        env:
+          OPENTILE_TESTDIR: OPENTILE_TESTDATA
         run: |
-          mkdir -p OPEN_TILER_TEST
-          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/CMU-1.svs -P OPEN_TILER_TEST/svs/CMU-1/
-          wget https://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu/CMU-1.ndpi -P OPEN_TILER_TEST/ndpi/CMU-1/
+          python -m pip install -U pip
+          python -m pip install requests
+          python tests/download_test_images.py
 
-  # RUN PYTEST
   tests:
     needs: [ cache_test_images ]
     name: pytest ${{ matrix.os }}::py${{ matrix.python-version }}
@@ -50,7 +52,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # cross os caching support, see: https://github.com/actions/cache/issues/591
-      - name: "Use GNU tar instead BSD tar"
+      - name: Use GNU tar instead BSD tar
         if: matrix.os == 'windows-latest'
         shell: cmd
         run: echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
@@ -58,8 +60,8 @@ jobs:
         id: cache-test-images
         uses: actions/cache@v2
         with:
-          key: test-image-cache-v1.0.1
-          path: OPEN_TILER_TEST
+          key: test-images-cache-${{ hashFiles('tests/download_test_images.py') }}
+          path: OPENTILE_TESTDATA
       - name: Check test images are loaded
         if: steps.cache-test-images.outputs.cache-hit != 'true'
         uses: actions/github-script@v3
@@ -90,5 +92,5 @@ jobs:
 
       - name: Run tests
         env:
-          OPEN_TILER_TESTDIR: OPEN_TILER_TEST
+          OPENTILE_TESTDIR: OPENTILE_TESTDATA
         run: pytest -v tests/

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -95,8 +95,8 @@ jobs:
         shell: pwsh
         if: matrix.os == 'windows-latest'
         run: |
-          Invoke-WebRequest -Uri https://sourceforge.net/projects/libjpeg-turbo/files/2.1.2/libjpeg-turbo-2.1.2-vc64.exe/download -OutFile libjpeg-turbo-2.1.2-vc64.exe -UserAgent "NativeHost"
-          7z e libjpeg-turbo-2.1.2-vc64.exe -oC:\Windows\System32 bin/turbojpeg.dll
+          Invoke-WebRequest -Uri https://sourceforge.net/projects/libjpeg-turbo/files/2.1.3/libjpeg-turbo-2.1.3-vc64.exe/download -OutFile libjpeg-turbo-2.1.3-vc64.exe -UserAgent "NativeHost"
+          7z e libjpeg-turbo-2.1.3-vc64.exe -oC:\Windows\System32 bin/turbojpeg.dll
 
       - name: Update pip and install pytest
         run: |

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -7,8 +7,15 @@ jobs:
     name: cache test images
     runs-on: ubuntu-latest
     steps:
+      # see:
+      #   - https://github.com/actions/checkout/issues/135
+      #   - https://github.com/actions/runner/issues/1246
+      - name: Prevent cache-miss on windows
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Load test images from cache
         id: cache-test-images
         uses: actions/cache@v2
@@ -43,8 +50,15 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
     steps:
+      # see:
+      #   - https://github.com/actions/checkout/issues/135
+      #   - https://github.com/actions/runner/issues/1246
+      - name: Prevent cache-miss on windows
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v2

--- a/.github/workflows/run_pytests.yaml
+++ b/.github/workflows/run_pytests.yaml
@@ -85,7 +85,9 @@ jobs:
 
       - name: Set up libjpegturbo Ubuntu
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y libturbojpeg
+        run: |
+          wget https://sourceforge.net/projects/libjpeg-turbo/files/2.1.3/libjpeg-turbo-official_2.1.3_amd64.deb
+          sudo dpkg -i libjpeg-turbo-official_2.1.3_amd64.deb
       - name: Set up libjpegturbo OSX
         if: matrix.os == 'macos-latest'
         run: brew install jpeg-turbo


### PR DESCRIPTION
Hello everyone,

This PR adds continuous integration tests for all OSes and multiple python versions.
Images are downloaded with the download script and cached and reused in all test jobs.

Currently tests on Windows and Ubuntu fail, because of #28.

Cheers,
Andreas :smiley: 