### PR TITLE
Do not trust the mcu tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] -
 
+## [0.7.1] - 2023-03-15
+
+### Fixed
+
+- Use MCU read from frame instead of from subsampling tag as the latter can be incorrect.
+
 ## [0.7.0] - 2023-02-13
 
 ### Changed
@@ -101,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of opentile.
 
-[Unreleased]: https://github.com/imi-bigpicture/opentile/compare/v0.7.0..HEAD
+[Unreleased]: https://github.com/imi-bigpicture/opentile/compare/v0.7.1..HEAD
+[0.7.1]: https://github.com/imi-bigpicture/opentile/compare/v0.7.0..v0.7.1
 [0.7.0]: https://github.com/imi-bigpicture/opentile/compare/v0.6.0..v0.7.0
 [0.6.0]: https://github.com/imi-bigpicture/opentile/compare/v0.5.0..v0.6.0
 [0.5.0]: https://github.com/imi-bigpicture/opentile/compare/v0.4.2..v0.5.0

--- a/opentile/__init__.py
+++ b/opentile/__init__.py
@@ -14,4 +14,4 @@
 
 from opentile.interface import OpenTile
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/opentile/jpeg.py
+++ b/opentile/jpeg.py
@@ -250,10 +250,9 @@ class Jpeg:
         """
         try:
             return self._turbo_jpeg.crop_multiple(frame, crop_parameters)
-        except OSError:
+        except OSError as exception:
             raise JpegCropError(
-                f"Crop of frame failed "
-                f"with parameters {crop_parameters}"
+                f"Crop of frame failed with parameters {crop_parameters}.", exception
             )
 
     @classmethod

--- a/opentile/jpeg.py
+++ b/opentile/jpeg.py
@@ -56,6 +56,25 @@ class Jpeg:
             turbo_path = find_turbojpeg_path()
         self._turbo_jpeg = TurboJPEG(turbo_path)
 
+    def get_mcu(self, frame: bytes) -> Size:
+        """Return MCU size read from frame header.
+
+        Parameters
+        ----------
+        frame: bytes
+            Frame with header.
+
+        Returns
+        ----------
+        bytes:
+            MCU size in header.
+        """
+        _, _, subsampling, _ = self._turbo_jpeg.decode_header(frame)
+        try:
+            return Size(tjMCUWidth[subsampling], tjMCUHeight[subsampling])
+        except IndexError:
+            raise ValueError(f"Unknown subsampling {subsampling}.")
+
     def concatenate_fragments(
         self,
         fragments: Iterator[bytes],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opentile"
-version = "0.7.0"
+version = "0.7.1"
 description = "Read tiles from wsi-TIFF files"
 authors = ["Erik O Gabrielsson <erik.o.gabrielsson@sectra.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The mcu tag can contain the wrong information, leading invalid crop positions. As the mcu is rarely needed (it is 'always' 8x8 for striped levels) we can parse it from the first frame header (and cache it)