### PR TITLE
Remove py3.9 from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please note that this is an early release and the API is not frozen yet. Functio
 
 ## Requirements
 
-*opentile* requires python >=3.9 and uses numpy, Pillow, TiffFile, and PyTurboJPEG (with lib-turbojpeg >= 2.1 ), imagecodecs, defusedxml, and ome-types.
+*opentile* requires python >=3.10 and uses numpy, Pillow, TiffFile, and PyTurboJPEG (with lib-turbojpeg >= 2.1 ), imagecodecs, defusedxml, and ome-types.
 
 ## Limitations
 


### PR DESCRIPTION
Sync with 0b246aa854d92c190c2758e087400fe309103203